### PR TITLE
feat/gemini 상담 기능에 dto 적용 및 재시도 retryable 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.30'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/http/test.http
+++ b/http/test.http
@@ -9,12 +9,12 @@ Content-Type: application/json
 
 
 ### AI 응급상담 전체 메시지 조회
-GET http://localhost:8080/first-aid/chat/a3030e97-0e7d-4528-9e16-3708f20b1a68
+GET http://localhost:8080/first-aid/chat/ab2fb108-03a5-4d1d-a01d-0141362394cd
 Accept: application/json
 
 
 ### 응급 상담 계속하기
-POST http://localhost:8080/first-aid/chat/a3030e97-0e7d-4528-9e16-3708f20b1a68
+POST http://localhost:8080/firsㄴt-aid/chat/ab2fb108-03a5-4d1d-a01d-0141362394cd
 Content-Type: application/json
 
 {

--- a/http/test.http
+++ b/http/test.http
@@ -14,7 +14,7 @@ Accept: application/json
 
 
 ### 응급 상담 계속하기
-POST http://localhost:8080/firsㄴt-aid/chat/ab2fb108-03a5-4d1d-a01d-0141362394cd
+POST http://localhost:8080/first-aid/chat/ab2fb108-03a5-4d1d-a01d-0141362394cd
 Content-Type: application/json
 
 {

--- a/src/main/java/com/gdgoc5/vitaltrip/config/RetryConfig.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.gdgoc5.vitaltrip.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/src/main/java/com/gdgoc5/vitaltrip/exception/NotFoundException.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.gdgoc5.vitaltrip.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+
+  public NotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatAdviceRequest.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatAdviceRequest.java
@@ -1,0 +1,6 @@
+package com.gdgoc5.vitaltrip.first_aid.dto;
+
+public record EmergencyChatAdviceRequest(
+        String emergencyType,
+        String userMessage
+) {}

--- a/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatAdviceResponse.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatAdviceResponse.java
@@ -1,0 +1,11 @@
+package com.gdgoc5.vitaltrip.first_aid.dto;
+
+public record EmergencyChatAdviceResponse(
+    String content,
+    String recommendedAction,
+    double confidence
+) {
+    public static EmergencyChatAdviceResponse from(String content, String recommendedAction, double confidence) {
+        return new EmergencyChatAdviceResponse(content, recommendedAction, confidence);
+    }
+}

--- a/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatContinueRequest.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatContinueRequest.java
@@ -1,0 +1,5 @@
+package com.gdgoc5.vitaltrip.first_aid.dto;
+
+public record EmergencyChatContinueRequest(
+    String userMessage
+) {}

--- a/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatMessageResponse.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatMessageResponse.java
@@ -1,0 +1,19 @@
+package com.gdgoc5.vitaltrip.first_aid.dto;
+
+import com.gdgoc5.vitaltrip.first_aid.entity.EmergencyChatMessage;
+
+import java.time.LocalDateTime;
+
+public record EmergencyChatMessageResponse(
+    String sender,
+    String message,
+    LocalDateTime createdAt
+) {
+    public static EmergencyChatMessageResponse from(EmergencyChatMessage message) {
+        return new EmergencyChatMessageResponse(
+            message.getSender(),
+            message.getMessage(),
+            message.getCreatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 응급처치 AI 상담 요청 및 응답 구조를 명확히 하기 위해 `EmergencyChatAdviceRequest`, `EmergencyChatAdviceResponse`, `EmergencyChatContinueRequest` DTO 클래스를 정의하고 적용했습니다
- 기존 `Map<String, String>` 방식의 요청 처리 및 응답 맵 구조를 모두 제거하고, 타입 안정성을 보장하는 DTO 기반으로 전환했습니다
- Gemini API 응답 파싱 또는 통신 오류 발생 시 자동으로 재시도할 수 있도록 `@Retryable` 어노테이션을 적용했습니다
- 재시도 기능을 활성화하기 위해 `@EnableRetry`가 포함된 `RetryConfig` 설정 클래스를 생성했습니다
- 예외 상황 발생 시 안정적으로 fallback 하거나 사용자에게 오류를 전달할 수 있도록 기본 예외 처리 흐름을 구성했습니다

---

### ✨ 참고 사항

- 추후 글로벌 예외 응답 형식 통일 및 로그 고도화 필요성 고려

---

### ⏰ 현재 버그

- 없음 (정상 요청 및 재시도 테스트 완료)

---

### ✏ Git Close

- Close #5