### PR TITLE
Feat: 응급처치 AI 응답 개선 - 증상 문장 삭제 및 블로그 링크 제공

### DIFF
--- a/src/main/java/com/gdgoc5/vitaltrip/first_aid/FirstAidController.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/first_aid/FirstAidController.java
@@ -82,18 +82,19 @@ public class FirstAidController {
                                     name = "초기 상담 요청 예시",
                                     value = """
                                     {
-                                       "result": "SUCCESS",
-                                       "message": "요청이 성공적으로 처리되었습니다.",
-                                       "data": {
-                                         "content": "Your situation sounds serious. Because you can't feel your hands, this could be the start of hypothermia. First, get out of the cold immediately. Find a warm place indoors, if possible. Remove any wet clothing. If you can't get indoors, find shelter from the wind and rain. Gently warm your hands, avoiding direct heat like a fire or hot water bottle, as this can cause burns. Try to warm your core first by layering dry blankets or clothing. Drink warm, non-alcoholic, non-caffeinated beverages, like broth or herbal tea if available. Monitor yourself closely. If your condition worsens, you develop confusion, or you have trouble shivering, seek immediate medical attention by calling emergency services.",
-                                         "recommendedAction": "Seek immediate medical attention if symptoms worsen or confusion develops.",
-                                         "confidence": 0.95,
-                                         "blogLinks": [
-                                           "https://www.rei.com/learn/expert-advice/hypothermia.html",
-                                           "https://www.mayoclinic.org/first-aid/first-aid-hypothermia/basics/art-20056683"
-                                         ]
-                                       }
-                                     }
+                                        "result": "SUCCESS",
+                                        "message": "요청이 성공적으로 처리되었습니다.",
+                                        "data": {
+                                          "content": "Your core body temperature is likely dangerously low (hypothermia). This is a serious medical emergency. Seek immediate medical attention; call emergency services (911 or your local emergency number) or have someone drive you to the nearest hospital right away. While waiting for help: Move to a warm place, if possible. Remove any wet clothing. If you can't move to a warmer place, protect yourself from the elements. Cover your head, neck, and groin. Try to get into dry clothes. If dry clothes aren't available, wring out wet clothes as much as possible. Drink warm, sweet fluids (like sugary tea or juice) if you are alert and able to swallow. Avoid alcohol. Apply warm compresses to your neck, armpits, and groin. Do not apply direct heat to your extremities (like hands and feet) as this can cause further damage. Monitor breathing and level of consciousness. Be prepared to administer CPR if needed.",
+                                          "recommendedAction": "Call emergency services immediately.",
+                                          "confidence": 0.95,
+                                          "blogLinks": [
+                                            "https://www.rei.com/learn/expert-advice/hypothermia.html",
+                                            "https://www.mayoclinic.org/diseases-conditions/hypothermia/diagnosis-treatment/drc-20352687"
+                                          ],
+                                          "sessionId": "98bc616c-447f-40dc-81a7-34e42cb255fc"
+                                        }
+                                      }
                                     """
                             )
                     )
@@ -170,13 +171,14 @@ public class FirstAidController {
                           "result": "SUCCESS",
                           "message": "요청이 성공적으로 처리되었습니다.",
                           "data": {
-                            "content": "While I cannot provide specific medical facility recommendations due to safety and real-time information limitations, immediately call emergency services (like 911 or your local emergency number). They can dispatch an ambulance and direct you to the nearest appropriate hospital equipped to handle hypothermia. Continue providing first aid while waiting: gently move the person to a warmer location if possible, remove any wet clothing and replace it with dry layers, and cover them with blankets. If they are conscious, offer warm (not hot) sweet drinks. Avoid rubbing their limbs vigorously as this can cause further harm.",
-                            "recommendedAction": "Call emergency services immediately and provide first aid while waiting for help.",
+                            "content": "Since you believe you are experiencing hypothermia, it is vital to seek immediate medical attention. I cannot provide specific hospital recommendations without knowing your location. Please provide your current location (city, address, or nearby landmark) so I can identify the nearest hospital with emergency services. While waiting for transport, continue warming measures like removing any wet clothing and covering yourself with dry blankets or clothing. Avoid rubbing the affected areas, as this can cause tissue damage. If possible, drink something warm and sweet if you are conscious and able to swallow safely.",
+                            "recommendedAction": "Provide location for nearest hospital search and continue warming measures while awaiting transport.",
                             "confidence": 0.95,
                             "blogLinks": [
-                              "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/cold-weather-safety/hypothermia.html",
-                              "https://www.mayoclinic.org/diseases-conditions/hypothermia/diagnosis-treatment/drc-20352687"
-                            ]
+                              "https://www.mayoclinic.org/first-aid/first-aid-hypothermia/basics/art-20056681",
+                              "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/winter-storm/hypothermia.html"
+                            ],
+                            "sessionId": null
                           }
                         }
                         """

--- a/src/main/java/com/gdgoc5/vitaltrip/first_aid/FirstAidController.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/first_aid/FirstAidController.java
@@ -82,9 +82,18 @@ public class FirstAidController {
                                     name = "초기 상담 요청 예시",
                                     value = """
                                     {
-                                      "emergencyType": "HYPOTHERMIA",
-                                      "userMessage": "It's so cold I can't feel my hands."
-                                    }
+                                       "result": "SUCCESS",
+                                       "message": "요청이 성공적으로 처리되었습니다.",
+                                       "data": {
+                                         "content": "Your situation sounds serious. Because you can't feel your hands, this could be the start of hypothermia. First, get out of the cold immediately. Find a warm place indoors, if possible. Remove any wet clothing. If you can't get indoors, find shelter from the wind and rain. Gently warm your hands, avoiding direct heat like a fire or hot water bottle, as this can cause burns. Try to warm your core first by layering dry blankets or clothing. Drink warm, non-alcoholic, non-caffeinated beverages, like broth or herbal tea if available. Monitor yourself closely. If your condition worsens, you develop confusion, or you have trouble shivering, seek immediate medical attention by calling emergency services.",
+                                         "recommendedAction": "Seek immediate medical attention if symptoms worsen or confusion develops.",
+                                         "confidence": 0.95,
+                                         "blogLinks": [
+                                           "https://www.rei.com/learn/expert-advice/hypothermia.html",
+                                           "https://www.mayoclinic.org/first-aid/first-aid-hypothermia/basics/art-20056683"
+                                         ]
+                                       }
+                                     }
                                     """
                             )
                     )
@@ -161,10 +170,13 @@ public class FirstAidController {
                           "result": "SUCCESS",
                           "message": "요청이 성공적으로 처리되었습니다.",
                           "data": {
-                            "content": "Since you are asking for the nearest hospital, your condition likely requires immediate medical attention. Continue any warming measures you are able to safely administer (remove wet clothing, add dry layers, seek shelter if not already there), but prioritize getting to a hospital. Use your phone to search for the closest emergency room (ER) or dial your local emergency number (like 911 in the US) for immediate transport. Don't delay transport to find the 'best' hospital; the closest one is the priority right now.",
-                            "recommendedAction": "Go to the nearest emergency room (ER) immediately. Call local emergency number if needed for transport.",
-                            "confidence": 1.0,
-                            "suggestedPhrase": "I think I have severe hypothermia. I'm feeling [mention specific symptoms like shivering, confusion, drowsiness]. I need help immediately."
+                            "content": "While I cannot provide specific medical facility recommendations due to safety and real-time information limitations, immediately call emergency services (like 911 or your local emergency number). They can dispatch an ambulance and direct you to the nearest appropriate hospital equipped to handle hypothermia. Continue providing first aid while waiting: gently move the person to a warmer location if possible, remove any wet clothing and replace it with dry layers, and cover them with blankets. If they are conscious, offer warm (not hot) sweet drinks. Avoid rubbing their limbs vigorously as this can cause further harm.",
+                            "recommendedAction": "Call emergency services immediately and provide first aid while waiting for help.",
+                            "confidence": 0.95,
+                            "blogLinks": [
+                              "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/cold-weather-safety/hypothermia.html",
+                              "https://www.mayoclinic.org/diseases-conditions/hypothermia/diagnosis-treatment/drc-20352687"
+                            ]
                           }
                         }
                         """

--- a/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatAdviceResponse.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatAdviceResponse.java
@@ -1,12 +1,14 @@
 package com.gdgoc5.vitaltrip.first_aid.dto;
 
+import java.util.List;
+
 public record EmergencyChatAdviceResponse(
     String content,
     String recommendedAction,
     double confidence,
-    String suggestedPhrase
+    List<String> blogLinks
 ) {
-    public static EmergencyChatAdviceResponse from(String content, String recommendedAction, double confidence, String suggestedPhrase) {
-        return new EmergencyChatAdviceResponse(content, recommendedAction, confidence, suggestedPhrase);
+    public static EmergencyChatAdviceResponse from(String content, String recommendedAction, double confidence, List<String> blogLinks) {
+        return new EmergencyChatAdviceResponse(content, recommendedAction, confidence, blogLinks);
     }
 }

--- a/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatAdviceResponse.java
+++ b/src/main/java/com/gdgoc5/vitaltrip/first_aid/dto/EmergencyChatAdviceResponse.java
@@ -1,14 +1,28 @@
 package com.gdgoc5.vitaltrip.first_aid.dto;
 
 import java.util.List;
+import java.util.UUID;
 
 public record EmergencyChatAdviceResponse(
     String content,
     String recommendedAction,
     double confidence,
-    List<String> blogLinks
+    List<String> blogLinks,
+    UUID sessionId
 ) {
+    public static EmergencyChatAdviceResponse from(String content, String recommendedAction, double confidence, List<String> blogLinks, UUID sessionId) {
+        return new EmergencyChatAdviceResponse(content, recommendedAction, confidence, blogLinks, sessionId);
+    }
+
     public static EmergencyChatAdviceResponse from(String content, String recommendedAction, double confidence, List<String> blogLinks) {
-        return new EmergencyChatAdviceResponse(content, recommendedAction, confidence, blogLinks);
+        return new EmergencyChatAdviceResponse(content, recommendedAction, confidence, blogLinks, null);
+    }
+
+    /**
+     * 이미 생성된 EmergencyChatAdviceResponse 객체에 sessionId를 추가하여 새로운 객체를 반환합니다.
+     * 초기 상담 후 세션 ID가 생성되는 경우에 사용됩니다.
+     */
+    public EmergencyChatAdviceResponse withSessionId(UUID sessionId) {
+        return new EmergencyChatAdviceResponse(this.content, this.recommendedAction, this.confidence, this.blogLinks, sessionId);
     }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 응급처치 AI 응답 포맷 변경
  - 기존에 제공하던 **suggestedPhrase** 필드를 제거했습니다.
  - 대신 증상 관련 **블로그 링크(blogLinks)** 2개를 응답에 포함하도록 수정했습니다.
  - **유튜브 링크**는 제공하지 않기로 했습니다. (존재하지 않는 영상 경로로 이동함)
- Markdown 포맷팅(예: `**굵은 글씨**`) 제거 요청을 프롬프트에 반영하여 Gemini 결과가 MDX 포맷 없이 반환되도록 수정했습니다.
- 초기 상담 요청 기능의 반환값에 `sessionId` 필드가 빠져있는 오류를 해결했습니다.

---

### ✨ 참고 사항

- 블로그 링크(blogLinks)는 응급처치와 관련된 자가 처치 정보를 제공하는 자료로 선택되었습니다.

---

### ⏰ 현재 버그

- 없음

---

### ✏ Git Close

- Close #12